### PR TITLE
add travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+dist: trusty
+sudo: false
+language: java
+
+cache:
+  directories:
+    - $HOME/.m2
+
+services:
+  - docker
+
+stages:
+  - build
+  - name: push
+    if: fork = false
+
+before_install:
+  - docker login -u="$QUAY_USER" -p="$QUAY_PASS" quay.io
+  - docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_PASS" registry.redhat.io
+
+jobs:
+  include:
+  - stage: build
+    script:
+    - mvn clean compile package
+  - stage: push
+    script:
+    - export REF_TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi`
+    - export COMMIT_TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
+    - docker build -t quay.io/emergencyresponsedemo/responder-service:$REF_TAG .
+    - docker tag quay.io/emergencyresponsedemo/responder-service:$REF_TAG quay.io/emergencyresponsedemo/responder-service:$COMMIT_TAG
+    - docker push quay.io/emergencyresponsedemo/responder-service:$REF_TAG
+    - docker push quay.io/emergencyresponsedemo/responder-service:$COMMIT_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.redhat.io/redhat-openjdk-18/openjdk18-openshift:1.5
+
+ENV JAVA_OPTIONS="-Dvertx.cacheDirBase=/tmp -Dvertx.disableDnsResolver=true" JAVA_APP_DIR=/deployments
+
+EXPOSE 8080 8778 9779
+
+COPY target/responder-service-0.0.1-SNAPSHOT.jar /deployments/


### PR DESCRIPTION
@johnfriz Mind taking a look?

The base image in the Dockerfile is based on the RHEL UBI

The build expects the following env vars set in Travis.
- Env vars for pulling from the Red Hat image registry (for the RHEL 8 UBI):
  - `RH_REGISTRY_USER` - token name for the Red Hat Image Registry
  - `RH_REGISTRY_PASS` - token secret for the Red Hat Image Registry
- Env vars for pushing to Quay
  - `QUAY_USER` - token name for the Quay Image Registry
  - `QUAY_PASS` - token secret for the Quay Image Registry

I still need to confirm this all works on a cluster